### PR TITLE
Add fix for partial swear word matching

### DIFF
--- a/src/main/java/com/uttesh/exude/handler/ScrawlWords.java
+++ b/src/main/java/com/uttesh/exude/handler/ScrawlWords.java
@@ -120,7 +120,7 @@ public class ScrawlWords {
                         String searchProp = String.valueOf(word.charAt(0));
                         String words = baseResource.getProperties(searchProp);
 
-                        if (words != null) {
+                        if (words != null && words.contains(word.toLowerCase())) {
                             final String[] swearWords = words.trim().split(SPLIT_ON_COMMA_AND_REMOVE_SPACE);
                             final String wordToCheck = word.toLowerCase();
 

--- a/src/main/java/com/uttesh/exude/handler/ScrawlWords.java
+++ b/src/main/java/com/uttesh/exude/handler/ScrawlWords.java
@@ -19,6 +19,8 @@ import com.uttesh.exude.common.BaseResource;
 import com.uttesh.exude.common.Constants;
 import com.uttesh.exude.stopping.StoppingResource;
 import com.uttesh.exude.swear.SwearResource;
+import org.apache.commons.lang.StringUtils;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,6 +29,8 @@ import java.util.regex.Pattern;
  * @author Uttesh Kumar T.H.
  */
 public class ScrawlWords {
+
+    private static final String SPLIT_ON_COMMA_AND_REMOVE_SPACE = "\\s*,\\s*";
 
     public static ScrawlWords instance = null;
 
@@ -96,7 +100,6 @@ public class ScrawlWords {
     }
 
     private boolean isValidWord(String word, BaseResource baseResource) {
-        boolean valid = true;
         try {
             word = word.toUpperCase();
 
@@ -109,15 +112,22 @@ public class ScrawlWords {
                         String searchProp = String.valueOf(word.charAt(0)) + String.valueOf(word.charAt(1));
                         String words = baseResource.getProperties(searchProp);
                         if (words != null && words.contains(word.toLowerCase())) {
-                            valid = false;
+                            return false;
                         }
                     }
                 } else if (baseResource instanceof SwearResource) {
                     if (Character.isLetter((char) firstCharater)) {
                         String searchProp = String.valueOf(word.charAt(0));
                         String words = baseResource.getProperties(searchProp);
-                        if (words != null && words.contains(word.toLowerCase())) {
-                            valid = false;
+
+                        if (words != null) {
+                            final String[] swearWords = words.trim().split(SPLIT_ON_COMMA_AND_REMOVE_SPACE);
+                            final String wordToCheck = word.toLowerCase();
+
+                            for (final String swearWord : swearWords) {
+                                if (StringUtils.equals(swearWord, wordToCheck))
+                                    return false;
+                            }
                         }
                     }
                 }
@@ -126,6 +136,6 @@ public class ScrawlWords {
             e.printStackTrace();
         }
         //System.out.println("word : "+word.toLowerCase()+": is valid : "+valid);
-        return valid;
+        return true;
     }
 }

--- a/src/test/java/TestData.java
+++ b/src/test/java/TestData.java
@@ -1,10 +1,11 @@
 
 import com.uttesh.exude.ExudeData;
 import com.uttesh.exude.exception.InvalidDataException;
-import java.io.IOException;
-import java.net.UnknownHostException;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
 
 /**
  *
@@ -46,6 +47,15 @@ public class TestData {
         String output = exudeData.getSwearWords(inputData);
         System.out.println("getSwearWordsFromData output swear words : " + output);
     }
+
+    @Test(enabled = false)
+    public void nonSwearWordsDontGetReturned() throws IOException, InvalidDataException {
+        String inputData = "This is as cool as me.";
+        String output = exudeData.getSwearWords(inputData);
+        assert output.isEmpty();
+        System.out.println("getSwearWordsFromData output swear words : " + output);
+    }
+
 
     @Test(enabled = false)
     public void filterStoppingFromLinkData() throws IOException, InvalidDataException {


### PR DESCRIPTION
@uttesh Link to issue: https://github.com/uttesh/exude/issues/3

- Updated the `isValidWord` method to check for equality between each swear word in a swear resource and the target word, instead of whether the swear resource simply contains the target word (bug details in the above issue)
- Added in a test for this